### PR TITLE
feat: 新規アップロードのための--seasonと--episode引数を追加

### DIFF
--- a/development_logs/2025-10-26-issue-103-session-1.md
+++ b/development_logs/2025-10-26-issue-103-session-1.md
@@ -1,0 +1,20 @@
+## 2025-10-26-issue-103-session-1.md
+
+### 作業内容
+
+-   `upload.ts` CLIスクリプトに `--season` と `--episode` 引数を追加。
+-   `spotifyUploader.ts` を更新し、これらの引数を使用するように変更（ハードコードされた値を置き換え）。
+-   `spotify-automation` の `README.md` に新しい引数のドキュメントを追加。
+-   `NewEpisodePage.ts` を修正し、シーズン/エピソード番号の入力とアサーションを統一的に処理するように変更。
+-   `newEpisode.spec.ts` (UI e2eテスト) を更新し、新しいフィールドが正しく入力されることを検証。
+-   `upload.ts` を修正し、`--dryRun` 時にJSON形式で出力するように変更。
+-   `cli.spec.ts` (CLI e2eテスト) を更新し、新しい引数が正しく処理されることを検証（JSON出力のパースを含む）。
+-   `AGENTS.MD` を更新し、すべてのコード変更にはテストの追加または修正が必須であること、および既存テストの修正を優先するルールを追加。
+-   認証スクリプト `saveAuth.ts` の `waitForURL` のロジックを修正し、ユーザーがブラウザを閉じるのを待つように変更。
+-   `authManager.ts` を修正し、`saveAuthState` が `BrowserContext` を受け取るように変更し、`localStorage` などの保存を削除。
+-   `authManager.ts` の `validateAuthFile` と `loadAuthState` を修正し、`cookies` と `timestamp` のみで認証ファイルの有効性を判断するように変更。
+-   `cli.spec.ts` の `JSON.parse` エラーを修正するため、`stdout` からJSON部分のみを抽出する正規表現を適用。
+
+### 発生した問題
+
+-   `pnpm nx affected:test` 実行時に、Nxの内部プロセスでパニックが発生し、テストがクラッシュした。


### PR DESCRIPTION
issue 103 の開発セッションが完了しました.\n\nこのPRには以下の変更が含まれます。\n\n- `upload.ts` CLIスクリプトに `--season` と `--episode` 引数を追加。\n- `spotifyUploader.ts` を更新し、これらの引数を使用するように変更（ハードコードされた値を置き換え）。\n- `spotify-automation` の `README.md` に新しい引数のドキュメントを追加。\n- `NewEpisodePage.ts` を修正し、シーズン/エピソード番号の入力とアサーションを統一的に処理するように変更。\n- `newEpisode.spec.ts` (UI e2eテスト) を更新し、新しいフィールドが正しく入力されることを検証。\n- `upload.ts` を修正し、`--dryRun` 時にJSON形式で出力するように変更。\n- `cli.spec.ts` (CLI e2eテスト) を更新し、新しい引数が正しく処理されることを検証（JSON出力のパースを含む）。\n- `AGENTS.MD` を更新し、すべてのコード変更にはテストの追加または修正が必須であること、および既存テストの修正を優先するルールを追加。\n- 認証スクリプト `saveAuth.ts` の `waitForURL` のロジックを修正し、ユーザーがブラウザを閉じるのを待つように変更。\n- `authManager.ts` を修正し、`saveAuthState` が `BrowserContext` を受け取るように変更し、`localStorage` などの保存を削除。\n- `authManager.ts` の `validateAuthFile` と `loadAuthState` を修正し、`cookies` と `timestamp` のみで認証ファイルの有効性を判断するように変更。\n- `cli.spec.ts` の `JSON.parse` エラーを修正するため、`stdout` からJSON部分のみを抽出する正規表現を適用。\n\n関連Issue: #103