### PR TITLE
認証ファイルの保存先パスを修正

### DIFF
--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -26,6 +26,12 @@ echo "Setting .vnc ownership..."
 chown -R devuser:devuser /home/devuser/.vnc
 echo "Ownership set."
 
+# Fix permissions for GitHub CLI config
+echo "Fixing GitHub CLI config permissions..."
+mkdir -p /home/devuser/.config/gh
+chown -R devuser:devuser /home/devuser/.config/gh
+echo "GitHub CLI config permissions fixed."
+
 # Fix workspace permissions
 echo "Fixing workspace permissions..."
 chown -R devuser:devuser /home/devuser/workspace || echo "Warning: chown failed for some files (likely read-only mounts)"

--- a/apps/ui-automations/spotify-automation/scripts/saveAuth.ts
+++ b/apps/ui-automations/spotify-automation/scripts/saveAuth.ts
@@ -1,5 +1,7 @@
 import { chromium } from '@playwright/test';
 import * as path from 'path';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
 import { AuthManager } from '../src/auth/authManager';
 
 const defaultAuthFilePath = path.resolve(
@@ -63,5 +65,26 @@ async function saveSpotifyAuth(options: SaveAuthOptions = {}): Promise<void> {
   }
 }
 
-// Execute the script
-saveSpotifyAuth().catch(console.error);
+// Parse command line arguments and execute the script
+async function main() {
+  const argv = await yargs(hideBin(process.argv))
+    .option('headless', {
+      type: 'boolean',
+      description: 'Run browser in headless mode',
+      default: false,
+    })
+    .option('outputPath', {
+      type: 'string',
+      description: 'Path to save the authentication file',
+      default: defaultAuthFilePath,
+    })
+    .help()
+    .parse();
+
+  await saveSpotifyAuth({
+    headless: argv.headless,
+    outputPath: argv.outputPath,
+  });
+}
+
+main().catch(console.error);

--- a/run_auth.sh
+++ b/run_auth.sh
@@ -1,1 +1,3 @@
-pnpm --filter @my-apps/spotify-automation exec ts-node scripts/saveAuth.ts
+#!/bin/bash
+mkdir -p credentials
+pnpm --filter @my-apps/spotify-automation exec ts-node scripts/saveAuth.ts --outputPath "$(pwd)/credentials/spotify-auth.json"


### PR DESCRIPTION
CIワークフローに合わせて、認証ファイルを `credentials/spotify-auth.json` に保存するように `run_auth.sh` と `saveAuth.ts` を修正しました。